### PR TITLE
[FIX] calendar_holiday: Remove "contract type" field in search of con…

### DIFF
--- a/calendar_holiday/models/hr_contract.py
+++ b/calendar_holiday/models/hr_contract.py
@@ -78,9 +78,7 @@ class HrContract(models.Model):
         contract_obj = self.env['hr.contract']
         date_begin = '{}-01-01'.format(fields.Date.from_string(
             fields.Date.today()).year)
-        cond = [('type_id', '=',
-                 self.env.ref('hr_contract.hr_contract_type_emp').id),
-                '|', ('date_end', '=', False),
+        cond = ['|', ('date_end', '=', False),
                 ('date_end', '>=', date_begin)]
         contracts = contract_obj.search(cond)
         for contract in contracts:


### PR DESCRIPTION
…tracts.
Se ha quitado en la búsqueda de contratos a generar calendario, el tipo de contrato, ya que tiene que tratar todos los tipos de contrato.