### PR TITLE
[IMP] hr_holidays_generator: Generate holidays for contracts with "jo…

### DIFF
--- a/hr_holidays_generator/README.rst
+++ b/hr_holidays_generator/README.rst
@@ -8,6 +8,9 @@ Hr holidays generator
 
 * New planner to automatically generate holidays for workers. Vacation days per
   month worked are defined in the company form.
+* Only vacations will be generated for those contracts that not have defined a
+  "Job Title", and if the contract has defined any "Job Title" her type of 
+  contract must have checked the option "To generate vacations automatically".
 
 
 Credits

--- a/hr_holidays_generator/__openerp__.py
+++ b/hr_holidays_generator/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Hr Holidays Generator",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",
@@ -20,7 +20,8 @@
     "data": [
         "data/hr_holidays_generator_data.xml",
         "views/res_company_view.xml",
-        "views/hr_holidays_status_view.xml"
+        "views/hr_holidays_status_view.xml",
+        "views/hr_contract_type_view.xml"
     ],
     "installable": True,
 }

--- a/hr_holidays_generator/models/hr.py
+++ b/hr_holidays_generator/models/hr.py
@@ -21,7 +21,10 @@ class HrContract(models.Model):
         first_day = today.replace(day=1)
         last_day = today.replace(day=lastday)
         cond = [('contract_stage_id', '!=', expired_stage.id),
-                ('date_start', '<', fields.Date.to_string(last_day))]
+                ('date_start', '<', fields.Date.to_string(last_day)),
+                ('job_id', '=', False),
+                '|', ('job_id', '!=', False),
+                ('type_id.vacations_automatically', '=', True)]
         contracts = self.search(cond)
         for c in contracts:
             days = (
@@ -60,3 +63,10 @@ class HrHolidaysStatus(models.Model):
 
     vacations_automatically = fields.Boolean(
         string='To generate vacations automatically')
+
+
+class HrContractType(models.Model):
+    _inherit = 'hr.contract.type'
+
+    vacations_automatically = fields.Boolean(
+        string='To generate vacations automatically', default=True)

--- a/hr_holidays_generator/tests/test_hr_holidays_generator.py
+++ b/hr_holidays_generator/tests/test_hr_holidays_generator.py
@@ -38,4 +38,4 @@ class TestHrHolidaysGenerator(common.TransactionCase):
                 ('type', '=', 'add')]
         holiday = self.env['hr.holidays'].search(cond, limit=1)
         self.assertEqual(
-            holiday.number_of_days_temp, 1.1, 'Bad holidays generated')
+            holiday.number_of_days_temp, 1.0, 'Bad holidays generated')

--- a/hr_holidays_generator/views/hr_contract_type_view.xml
+++ b/hr_holidays_generator/views/hr_contract_type_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="hr_contract_type_view_form_inh_automatic_holidays">
+            <field name="name">hr.contract.type.view.form.inh.automatic.holidays</field>
+            <field name="model">hr.contract.type</field>
+            <field name="inherit_id" ref="hr_contract.hr_contract_type_view_form" />
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field name="vacations_automatically" />
+                    <group colspan="2" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="hr_contract_type_view_tree_inh_automatic_holidays">
+            <field name="name">hr.contract.type.view.tree.inh.automatic.holidays</field>
+            <field name="model">hr.contract.type</field>
+            <field name="inherit_id" ref="hr_contract.hr_contract_type_view_tree" />
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field name="vacations_automatically" />
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
…b tittle" and type contract selected.
Seleccionar aquellos contractos que no tienen definido un título de trabajo, y si tienes definido un título de trabajo que su tipo de contrato este marcado como que hay que generar vacaciones automáticamente.