### PR TITLE
[18.0][FIX] hr_attendance_leave_report: Do not register a record in "…

### DIFF
--- a/hr_attendance_leave_report/README.rst
+++ b/hr_attendance_leave_report/README.rst
@@ -14,6 +14,8 @@ Hr attendance leave report
   worked, holidays, and absences.
 * As a condition... that the worker has an assigned contract.
 * New Scheduled Action "Activate today's day in Attendances And Absences".
+* New server action "Recalculate Day/Worker" in "Attendances And Absences"
+  object.
 
 
 Bug Tracker

--- a/hr_attendance_leave_report/i18n/ca_ES.po
+++ b/hr_attendance_leave_report/i18n/ca_ES.po
@@ -267,3 +267,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_attendance_leave_report.field_hr_attendance_leave__worked_hours
 msgid "Worked hours"
 msgstr ""
+
+#. module: hr_attendance_leave_report
+#: model:ir.actions.server,name:hr_attendance_leave_report.action_recaculate_hr_attendance_leave
+msgid "Recalculate Day/Worker"
+msgstr ""
+

--- a/hr_attendance_leave_report/i18n/en_GB.po
+++ b/hr_attendance_leave_report/i18n/en_GB.po
@@ -267,3 +267,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_attendance_leave_report.field_hr_attendance_leave__worked_hours
 msgid "Worked hours"
 msgstr ""
+
+#. module: hr_attendance_leave_report
+#: model:ir.actions.server,name:hr_attendance_leave_report.action_recaculate_hr_attendance_leave
+msgid "Recalculate Day/Worker"
+msgstr ""
+

--- a/hr_attendance_leave_report/i18n/es.po
+++ b/hr_attendance_leave_report/i18n/es.po
@@ -272,3 +272,9 @@ msgstr "Día trabajo"
 #: model:ir.model.fields,field_description:hr_attendance_leave_report.field_hr_attendance_leave__worked_hours
 msgid "Worked hours"
 msgstr "Horas trabajadas"
+
+#. module: hr_attendance_leave_report
+#: model:ir.actions.server,name:hr_attendance_leave_report.action_recaculate_hr_attendance_leave
+msgid "Recalculate Day/Worker"
+msgstr "Recalcular Día/Trabajador"
+

--- a/hr_attendance_leave_report/i18n/fr.po
+++ b/hr_attendance_leave_report/i18n/fr.po
@@ -267,3 +267,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_attendance_leave_report.field_hr_attendance_leave__worked_hours
 msgid "Worked hours"
 msgstr ""
+
+#. module: hr_attendance_leave_report
+#: model:ir.actions.server,name:hr_attendance_leave_report.action_recaculate_hr_attendance_leave
+msgid "Recalculate Day/Worker"
+msgstr ""
+

--- a/hr_attendance_leave_report/i18n/hr_attendance_leave_report.pot
+++ b/hr_attendance_leave_report/i18n/hr_attendance_leave_report.pot
@@ -267,3 +267,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_attendance_leave_report.field_hr_attendance_leave__worked_hours
 msgid "Worked hours"
 msgstr ""
+
+#. module: hr_attendance_leave_report
+#: model:ir.actions.server,name:hr_attendance_leave_report.action_recaculate_hr_attendance_leave
+msgid "Recalculate Day/Worker"
+msgstr ""
+

--- a/hr_attendance_leave_report/models/hr_attendance_leave.py
+++ b/hr_attendance_leave_report/models/hr_attendance_leave.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import _, api, fields, models
 
+from .._common import _catch_employees_dates_to_treat
+
 
 class HrAttendanceLeave(models.Model):
     _name = "hr.attendance.leave"
@@ -113,6 +115,8 @@ class HrAttendanceLeave(models.Model):
                 )
 
     def _update_attendance_leave_info(self, employee, work_date):
+        if not employee or not employee.user_id:
+            return
         contract, vals = self._initialize_vals(employee, work_date)
         if contract:
             vals = self._get_festive(contract, work_date, vals)
@@ -246,3 +250,11 @@ class HrAttendanceLeave(models.Model):
                     vals["non_remunerated_hours"] += hours
             vals["day_type"] = " + ".join(names)
         return vals
+
+    def recaculate_hr_attendance_leave(self):
+        for record in self:
+            employees_dates = []
+            employees_dates = _catch_employees_dates_to_treat(
+                employees_dates, record.employee_id, record.work_day, record.work_day
+            )
+            self.env["hr.attendance.leave"]._treat_employee_dates(employees_dates)

--- a/hr_attendance_leave_report/views/hr_attendance_leave_views.xml
+++ b/hr_attendance_leave_report/views/hr_attendance_leave_views.xml
@@ -223,4 +223,23 @@
     groups="hr_attendance.group_hr_attendance_officer"
     action="action_hr_attendance_leave_manager"
   />
+
+  <record id="action_recaculate_hr_attendance_leave" model="ir.actions.server">
+    <field name="name">Recalculate Day/Worker</field>
+    <field name="model_id" ref="hr_attendance_leave_report.model_hr_attendance_leave" />
+    <field
+      name="binding_model_id"
+      ref="hr_attendance_leave_report.model_hr_attendance_leave"
+    />
+    <field
+      name='groups_id'
+      eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"
+    />
+    <field name="state">code</field>
+    <field name="sequence">10</field>
+    <field name="code">
+            if records:
+                action = records.recaculate_hr_attendance_leave()
+        </field>
+  </record>
 </odoo>


### PR DESCRIPTION
…Attendances and Absences" when there is no employee, or the employee is not related to a user.